### PR TITLE
Drop Item if Inventory Full Feature & Small Bug Fix

### DIFF
--- a/src/main/java/com/leonardobishop/commandtoitem/CommandToItem.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/CommandToItem.java
@@ -131,6 +131,7 @@ public class CommandToItem extends JavaPlugin {
         FULL_INV("full-inv", "&c%player%'s inventory is full!"),
         GIVE_ITEM("give-item", "&6Given &e%player% %item%&6."),
         RECEIVE_ITEM("receive-item", "&6You have been given %item%&6."),
+        RECEIVE_ITEM_INVENTORY_FULL("receive-item-inventory-full", "&6You have been given %item%&6, but it was dropped at your feet because your inventory is full."),
         COOLDOWN("cooldown", "&cYou must wait &4%cooldown% &cseconds before using this item again.");
 
         private String id;

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -72,7 +72,14 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                     return true;
                 }
                 if (target.getInventory().firstEmpty() == -1) {
-                    sender.sendMessage(plugin.getMessage(CommandToItem.Message.FULL_INV));
+                    if (plugin.getConfig().getBoolean("options.drop-if-full-inventory", true)) {
+                        target.getWorld().dropItem(target.getLocation(), item.getItemStack());
+                        target.sendMessage(plugin.getMessage(CommandToItem.Message.RECEIVE_ITEM_INVENTORY_FULL).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()));
+
+                        sender.sendMessage(plugin.getMessage(CommandToItem.Message.GIVE_ITEM).replace("%player%", target.getName()).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()));
+                    } else {
+                        sender.sendMessage(plugin.getMessage(CommandToItem.Message.FULL_INV);
+                    }
                     return true;
                 }
 

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -78,7 +78,7 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
 
                         sender.sendMessage(plugin.getMessage(CommandToItem.Message.GIVE_ITEM).replace("%player%", target.getName()).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()));
                     } else {
-                        sender.sendMessage(plugin.getMessage(CommandToItem.Message.FULL_INV);
+                        sender.sendMessage(plugin.getMessage(CommandToItem.Message.FULL_INV).replace("%player%", target.getName()));
                     }
                     return true;
                 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -125,10 +125,12 @@ items:
 # Options here
 options:
   show-receive-message: true
+  drop-if-full-inventory: false # If true and the player has a full inventory, drop the item at their feet. If false and the player has a full inventory, the item is lost.
 
 # Messages here
 messages:
   full-inv: "&c%player%'s inventory is full!"
   give-item: "&6Given &e%player% %item%&6."
   receive-item: "&6You have been given %item%&6."
+  receive-item-inventory-full: "&6You have been given %item%&6, but it was dropped at your feet because your inventory is full."
   cooldown: "&cYou must wait &4%cooldown% &cseconds before using this item again."


### PR DESCRIPTION
- Added a boolean in the config. When set to true, drop the item at the player's feet instead of failing.
- Fix player name placeholder not being replaced when sending the regular inventory full message.