### PR TITLE
Item Amounts, New Config Messages

### DIFF
--- a/src/main/java/com/leonardobishop/commandtoitem/CommandToItem.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/CommandToItem.java
@@ -136,7 +136,12 @@ public class CommandToItem extends JavaPlugin {
         RECEIVE_ITEM("receive-item", "&6You have been given %amount% %item%&6."),
         RECEIVE_ITEM_INVENTORY_FULL("receive-item-inventory-full", "&6You have been given %item%&6, but it was dropped at your feet because your inventory is full."),
         COOLDOWN("cooldown", "&6You have been given %given_amount% %item%&6, but %dropped_amount% dropped at your feet because your inventory is full."),
-        NO_PERMISSION("no-permission", "&cYou cannot use this item.");
+        NO_PERMISSION("no-permission", "&cYou cannot use this item."),
+        ITEM_LIST("item-list", "&6Items: &e%items%"),
+        RELOAD("reload", "&7CommandToItem has been reloaded"),
+        PLAYER_NOT_FOUND("player-not-found", "&cThe specified player could not be found."),
+        ITEM_NOT_FOUND("item-not-found", "&cThe item &4%item%&c could not be found."),
+        ITEM_LIMITS("item-limits", "&cPlease enter an amount between &4%min%&c and &4%max%&c.");
 
         private final String id;
         private final String def; // (default message if undefined)

--- a/src/main/java/com/leonardobishop/commandtoitem/CommandToItem.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/CommandToItem.java
@@ -131,11 +131,11 @@ public class CommandToItem extends JavaPlugin {
 
     public enum Message {
 
-        FULL_INV("full-inv", "&c%player%'s inventory is full!"),
-        GIVE_ITEM("give-item", "&6Given &e%player% %item%&6."),
-        RECEIVE_ITEM("receive-item", "&6You have been given %item%&6."),
+        FULL_INV("full-inv", "&c%player% doesn't have enough space in their inventory!"),
+        GIVE_ITEM("give-item", "&6Given &e%player% &6%amount% %item%&6."),
+        RECEIVE_ITEM("receive-item", "&6You have been given %amount% %item%&6."),
         RECEIVE_ITEM_INVENTORY_FULL("receive-item-inventory-full", "&6You have been given %item%&6, but it was dropped at your feet because your inventory is full."),
-        COOLDOWN("cooldown", "&cYou must wait &4%cooldown% &cseconds before using this item again."),
+        COOLDOWN("cooldown", "&6You have been given %given_amount% %item%&6, but %dropped_amount% dropped at your feet because your inventory is full."),
         NO_PERMISSION("no-permission", "&cYou cannot use this item.");
 
         private final String id;

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -46,15 +46,13 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
 
                 Player target = null;
 
-                if (args.length == 2) {
+                if (args.length >= 2) {
                     for (Player p : Bukkit.getServer().getOnlinePlayers()) {
                         if (!p.getName().equalsIgnoreCase(args[1]))
                             continue;
                         target = p;
                         break;
                     }
-                } else if (sender instanceof Player) {
-                    target = ((Player) sender);
                 }
 
                 if (target == null) {

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -34,12 +34,12 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                     for (Item item : plugin.getItems()) {
                         ids.add(item.getId());
                     }
-                    sender.sendMessage(ChatColor.GOLD + "Items: " + ChatColor.YELLOW + String.join(ChatColor.GRAY + ", " + ChatColor.YELLOW, ids));
+                    sender.sendMessage(plugin.getMessage(CommandToItem.Message.ITEM_LIST).replace("%items%", String.join(", ", ids)));
                     return true;
                 } else if (args[0].equals("reload")) {
                     plugin.reloadConfig();
                     refreshNameCache();
-                    sender.sendMessage(ChatColor.GRAY + "CommandToItem has been reloaded");
+                    sender.sendMessage(plugin.getMessage(CommandToItem.Message.RELOAD));
                     return true;
                 }
 
@@ -56,7 +56,7 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                 }
 
                 if (target == null) {
-                    sender.sendMessage(ChatColor.RED + "The specified player could not be found.");
+                    sender.sendMessage(plugin.getMessage(CommandToItem.Message.PLAYER_NOT_FOUND));
                     return true;
                 }
 
@@ -72,12 +72,12 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
 
                 Item item = getItemByName(args[0]);
                 if (item == null) {
-                    sender.sendMessage(ChatColor.RED + "The item " + ChatColor.DARK_RED + args[0] + ChatColor.RED + " could not be found.");
+                    sender.sendMessage(plugin.getMessage(CommandToItem.Message.ITEM_NOT_FOUND).replace("%item%", args[0]));
                     return true;
                 }
                 // Limitations for item amount
                 if (amount > maxAllowedItems || amount < 1) {
-                    sender.sendMessage(ChatColor.RED + "Please enter an amount between " + ChatColor.DARK_RED + "1" + ChatColor.RED + " and " + ChatColor.DARK_RED + maxAllowedItems + ChatColor.RED + ".");
+                    sender.sendMessage(plugin.getMessage(CommandToItem.Message.ITEM_LIMITS).replace("%min%", "1").replace("%max%", Integer.toString(maxAllowedItems)));
                     return true;
                 }
 

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -103,12 +103,19 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                     }
                 }
 
-                sender.sendMessage(plugin.getMessage(CommandToItem.Message.GIVE_ITEM).replace("%player%",
-                        target.getName()).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()));
+                int lostItems = amount - addedItems;
                 if (plugin.getConfig().getBoolean("options.show-receive-message", true)) {
-                    target.sendMessage(plugin.getMessage(CommandToItem.Message.RECEIVE_ITEM).replace("%player%",
-                            target.getName()).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()));
+                    if (lostItems > 0) {
+                        // If some items were dropped in the process, notify user
+                        target.sendMessage(plugin.getMessage(CommandToItem.Message.RECEIVE_ITEM_INVENTORY_FULL).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()).replace("%given_amount%", Integer.toString(amount)).replace("%dropped_amount%", Integer.toString(lostItems)));
+                    } else {
+                        // If no items lost, send success message
+                        target.sendMessage(plugin.getMessage(CommandToItem.Message.RECEIVE_ITEM).replace("%player%",
+                                target.getName()).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()).replace("%amount%", Integer.toString(amount)));
+                    }
                 }
+
+                sender.sendMessage(plugin.getMessage(CommandToItem.Message.GIVE_ITEM).replace("%player%", target.getName()).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()).replace("%amount%", Integer.toString(amount)));
                 return true;
             }
 

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -19,6 +19,7 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
 
     private CommandToItem plugin;
     private ArrayList<String> nameCache;
+    private final int maxAllowedItems = 2147483647;
 
     public BaseCommand(CommandToItem plugin) {
         this.plugin = plugin;
@@ -60,21 +61,24 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                     return true;
                 }
 
-                Item item = null;
-                for (Item i : plugin.getItems()) {
-                    if (i.getId().equals(args[0])) {
-                        item = i;
-                        break;
+                // If a third argument is specified, validate it as an amount. Otherwise, use 1 as default
+                int amount = 1;
+                if (args.length > 2) {
+                    try {
+                        amount = Integer.parseInt(args[2]);
+                    } catch (NumberFormatException | NullPointerException e) {
+                        amount = 0;
                     }
                 }
                 if (item == null) {
                     sender.sendMessage(ChatColor.RED + "The item " + ChatColor.DARK_RED + args[0] + ChatColor.RED + " could not be found.");
                     return true;
                 }
-                if (target.getInventory().firstEmpty() == -1) {
-                    if (plugin.getConfig().getBoolean("options.drop-if-full-inventory", true)) {
-                        target.getWorld().dropItem(target.getLocation(), item.getItemStack());
-                        target.sendMessage(plugin.getMessage(CommandToItem.Message.RECEIVE_ITEM_INVENTORY_FULL).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()));
+                // Limitations for item amount
+                if (amount > maxAllowedItems || amount < 1) {
+                    sender.sendMessage(ChatColor.RED + "Please enter an amount between " + ChatColor.DARK_RED + "1" + ChatColor.RED + " and " + ChatColor.DARK_RED + maxAllowedItems + ChatColor.RED + ".");
+                    return true;
+                }
 
                         sender.sendMessage(plugin.getMessage(CommandToItem.Message.GIVE_ITEM).replace("%player%", target.getName()).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()));
                     } else {

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -121,7 +121,7 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
             sender.sendMessage(ChatColor.GOLD + "" + ChatColor.BOLD + "Command To Item (ver " + plugin.getDescription().getVersion() + ")");
             sender.sendMessage(ChatColor.GRAY + "<> = required, [] = optional");
             sender.sendMessage(ChatColor.YELLOW + "/cti :" + ChatColor.GRAY + " view this menu");
-            sender.sendMessage(ChatColor.YELLOW + "/cti <item> [player] :" + ChatColor.GRAY + " give <item> to [player] (or self if blank)");
+            sender.sendMessage(ChatColor.YELLOW + "/cti <item> <player> [amount] :" + ChatColor.GRAY + " give [amount] of <item> to <player> (or 1 if no amount specified)");
             sender.sendMessage(ChatColor.YELLOW + "/cti list :" + ChatColor.GRAY + " list all items");
             sender.sendMessage(ChatColor.YELLOW + "/cti reload :" + ChatColor.GRAY + " reload the config");
             return true;

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -9,6 +9,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.StringUtil;
 
 import java.util.ArrayList;
@@ -70,6 +71,9 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                         amount = 0;
                     }
                 }
+
+                Item item = getItemByName(args[0]);
+                ItemStack itemStack = item.getItemStack(); // Get the item stack
                 if (item == null) {
                     sender.sendMessage(ChatColor.RED + "The item " + ChatColor.DARK_RED + args[0] + ChatColor.RED + " could not be found.");
                     return true;
@@ -130,5 +134,16 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
         }
 //        nameCache.add("list");
 //        nameCache.add("reload");
+    }
+
+    private Item getItemByName(String name) {
+        Item item = null;
+        for (Item i : plugin.getItems()) {
+            if (i.getId().equals(name)) {
+                item = i;
+                break;
+            }
+        }
+        return item;
     }
 }

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -73,7 +73,6 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                 }
 
                 Item item = getItemByName(args[0]);
-                ItemStack itemStack = item.getItemStack(); // Get the item stack
                 if (item == null) {
                     sender.sendMessage(ChatColor.RED + "The item " + ChatColor.DARK_RED + args[0] + ChatColor.RED + " could not be found.");
                     return true;
@@ -83,6 +82,8 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                     sender.sendMessage(ChatColor.RED + "Please enter an amount between " + ChatColor.DARK_RED + "1" + ChatColor.RED + " and " + ChatColor.DARK_RED + maxAllowedItems + ChatColor.RED + ".");
                     return true;
                 }
+
+                ItemStack itemStack = item.getItemStack(); // Get the item stack
 
                 // If adding items would cause inventory overflow and lost items can't be dropped at feet, cancel adding items
                 if (!plugin.getConfig().getBoolean("options.drop-if-full-inventory", false) && !canAddItems(amount, target, itemStack)) {

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -140,6 +140,27 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
             StringUtil.copyPartialMatches(args[0], nameCache, completions);
             Collections.sort(completions);
             return completions;
+        } else if (args.length == 3) {
+            // Add common amounts that you specify do for this item
+            Item item = getItemByName(args[0]); // Get item from arg name
+            List<String> amounts = new ArrayList<>(); // List to store all numbers
+
+            // If item doesn't exist, return blank array list
+            if (item == null) return amounts;
+
+            int maxStackSize = item.getItemStack().getMaxStackSize(); // Get max stack size of this item
+            for (int i = 1; i <= maxStackSize; i++) {
+                // Add numbers from 1 to max item size
+                amounts.add(Integer.toString(i));
+            }
+            if (!amounts.contains("64")) amounts.add("64"); // If 64 not in list, add it
+
+            // Match typed number to the list created
+            List<String> completions = new ArrayList<>(); // List to store all matched numbers
+            StringUtil.copyPartialMatches(args[2], amounts, completions);
+            Collections.sort(completions);
+
+            return completions;
         }
         return null;
     }

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -90,7 +90,18 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
                     return true;
                 }
 
-                target.getInventory().addItem(item.getItemStack());
+                // Add items one-by-one
+                int addedItems = 0;
+                for (int i = 0; i < amount; i++) {
+                    if (!canAddItems(1, target, itemStack)) {
+                        // If inventory is full, drop item
+                        target.getWorld().dropItem(target.getLocation(), item.getItemStack());
+                    } else {
+                        // If inventory has space, add item
+                        target.getInventory().addItem(itemStack);
+                        addedItems++;
+                    }
+                }
 
                 sender.sendMessage(plugin.getMessage(CommandToItem.Message.GIVE_ITEM).replace("%player%",
                         target.getName()).replace("%item%", item.getItemStack().getItemMeta().getDisplayName()));

--- a/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
+++ b/src/main/java/com/leonardobishop/commandtoitem/commands/BaseCommand.java
@@ -136,6 +136,9 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
         }
         if (args.length < 2) {
             List<String> completions = new ArrayList<>();
+            List<String> options = nameCache;
+            options.add("reload");
+            options.add("list");
             StringUtil.copyPartialMatches(args[0], nameCache, completions);
             Collections.sort(completions);
             return completions;
@@ -169,8 +172,6 @@ public class BaseCommand implements CommandExecutor, TabCompleter {
         for (Item i : plugin.getItems()) {
             nameCache.add(i.getId());
         }
-//        nameCache.add("list");
-//        nameCache.add("reload");
     }
 
     private Item getItemByName(String name) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -132,9 +132,9 @@ options:
 
 # Messages here
 messages:
-  full-inv: "&c%player%'s inventory is full!"
-  give-item: "&6Given &e%player% %item%&6."
-  receive-item: "&6You have been given %item%&6."
-  receive-item-inventory-full: "&6You have been given %item%&6, but it was dropped at your feet because your inventory is full."
+  full-inv: "&c%player%'s doesn't have enough space in their inventory!"
+  give-item: "&6Given &e%player% &6%amount% %item%&6."
+  receive-item: "&6You have been given %amount% %item%&6."
+  receive-item-inventory-full: "&6You have been given %given_amount% %item%&6, but %dropped_amount% dropped at your feet because your inventory is full."
   cooldown: "&cYou must wait &4%cooldown% &cseconds before using this item again."
   no-permission: "&cYou cannot use this item."

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -138,3 +138,8 @@ messages:
   receive-item-inventory-full: "&6You have been given %given_amount% %item%&6, but %dropped_amount% dropped at your feet because your inventory is full."
   cooldown: "&cYou must wait &4%cooldown% &cseconds before using this item again."
   no-permission: "&cYou cannot use this item."
+  item-list: "&6Items: &e%items%"
+  reload: "&7CommandToItem has been reloaded"
+  player-not-found: "&cThe specified player could not be found."
+  item-not-found: "&cThe item &4%item%&c could not be found."
+  item-limits: "&cPlease enter an amount between &4%min%&c and &4%max%&c."

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -132,7 +132,7 @@ options:
 
 # Messages here
 messages:
-  full-inv: "&c%player%'s doesn't have enough space in their inventory!"
+  full-inv: "&c%player% doesn't have enough space in their inventory!"
   give-item: "&6Given &e%player% &6%amount% %item%&6."
   receive-item: "&6You have been given %amount% %item%&6."
   receive-item-inventory-full: "&6You have been given %given_amount% %item%&6, but %dropped_amount% dropped at your feet because your inventory is full."


### PR DESCRIPTION
Resolves #8 

New additions:
- Add ability for user to specify item amount when giving item
- Add items one-by-one instead of all at once so that they fill up existing item stacks in the player's inventory and respect the item's max stack size
- Add tab completion for item amount as 3rd command argument
- Add reload and list commands to tab completion
- Add new config messages for item list, reload, player not found, item not found, and item limits

Things removed:
- Remove ability for username argument to be left blank when giving item because there'd be no way to get item amount

Changes:
- Changed config strings for full inventory, give item, receive item, and receive item when inventory full 
- Changed help text for main command 

Please let me know if I missed anything or if there's a better way of doing something.